### PR TITLE
Combine libDeep and sc_lib into single shared object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ examples/db_probe/test
 testing/.mitigated_all
 
 bin/shortcut/sc_lib.so
+
+*.o

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,5 +1,5 @@
 # Variables inherited from parent
-EXECS=idt_tool vm_tool snapshot_tool cr_tool shortcut/sc_lib.so shortcut/deep_sc/libDeep.so
+EXECS=idt_tool vm_tool snapshot_tool cr_tool shortcut/sc_lib.so shortcut/sc_lib.o shortcut/deep_sc/deep_sc.o
 
 # Variable to toggle deep shortcutting, undefine if doing shallow shortcuts
 DEEP_SC_DEFINE = "-UDEEP_SHORTCUT"
@@ -8,6 +8,9 @@ DEEP_SC_DEFINE = "-UDEEP_SHORTCUT"
 # makefile just so we can make use of the inherited variables.
 redirect:
 	make -C ../ bin
+
+%.o: %.c
+	$(CC) -c $(CFLAGS) -I $(SYMLIB_INCLUDE_DIR) -fPIC -o $@ $<
 
 # Don't call this target directly
 all: $(EXECS)
@@ -24,11 +27,8 @@ idt_tool: idt_tool.c idt_tool.h | $(DEPENDENCY_LIBS)
 snapshot_tool: snapshot_tool.c snapshot_tool.h | $(DEPENDENCY_LIBS)
 	$(CC) $(CFLAGS) -o $@ $< $(SYMLIB_LINK) -I $(SYMLIB_INCLUDE_DIR)
 
-shortcut/sc_lib.so: shortcut/sc_lib.c shortcut/sc_lib.h shortcut/deep_sc/libDeep.so
-	gcc $(CFLAGS) -shared -fPIC -o $@ $(SYMLIB_LINK) -lDeep $< -I $(SYMLIB_INCLUDE_DIR) -L shortcut/deep_sc $(DEEP_SC_DEFINE)
-
-shortcut/deep_sc/libDeep.so: shortcut/deep_sc/deep_sc.c shortcut/deep_sc/deep_sc.h
-	gcc $(CFLAGS) -shared -fPIC -o $@ $^ $(SYMLIB_LINK) -I $(SYMLIB_INCLUDE_DIR) $(DEEP_SC_DEFINE)
+shortcut/sc_lib.so: shortcut/sc_lib.o shortcut/sc_lib.h shortcut/deep_sc/deep_sc.o shortcut/deep_sc/deep_sc.h
+	gcc $(CFLAGS) -shared -fPIC -o $@ $(SYMLIB_LINK) $< $(DEEP_SC_DEFINE)
 
 clean:
 	rm -rf $(EXECS)


### PR DESCRIPTION
It looks like sc_lib.so is the only consumer for libDeep.so and all of the code in libdDeep is ifdef'd out when building for shallow short cuts. Instead of keeping these libraries separate (and causing difficulty when deploying to standard environments) lets merge them.