### PR TITLE
Fix Deep Shortcuts

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -10,7 +10,7 @@ redirect:
 	make -C ../ bin
 
 %.o: %.c
-	$(CC) -c $(CFLAGS) -I $(SYMLIB_INCLUDE_DIR) -fPIC -o $@ $<
+	$(CC) -c $(CFLAGS) -I $(SYMLIB_INCLUDE_DIR) $(DEEP_SC_DEFINE) -fPIC -o $@ $<
 
 # Don't call this target directly
 all: $(EXECS)


### PR DESCRIPTION
The combination of libdeep and sc_lib broke deep shortcuts because we had no way to pass the define to the C file.