### PR TITLE
Fix library linkage and fully express dependencies

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -12,6 +12,10 @@ redirect:
 %.o: %.c
 	$(CC) -c $(CFLAGS) -I $(SYMLIB_INCLUDE_DIR) $(DEEP_SC_DEFINE) -fPIC -o $@ $<
 
+shortcut/sc_lib.o: shortcut/sc_lib.c shortcut/sc_lib.h
+
+shortcut/deep_sc/deep_sc.o: shortcut/deep_sc/deep_sc.c shortcut/deep_sc/deep_sc.h
+
 # Don't call this target directly
 all: $(EXECS)
 
@@ -27,8 +31,8 @@ idt_tool: idt_tool.c idt_tool.h | $(DEPENDENCY_LIBS)
 snapshot_tool: snapshot_tool.c snapshot_tool.h | $(DEPENDENCY_LIBS)
 	$(CC) $(CFLAGS) -o $@ $< $(SYMLIB_LINK) -I $(SYMLIB_INCLUDE_DIR)
 
-shortcut/sc_lib.so: shortcut/sc_lib.o shortcut/sc_lib.h shortcut/deep_sc/deep_sc.o shortcut/deep_sc/deep_sc.h
-	gcc $(CFLAGS) -shared -fPIC -o $@ $(SYMLIB_LINK) $< $(DEEP_SC_DEFINE)
+shortcut/sc_lib.so: shortcut/sc_lib.o shortcut/deep_sc/deep_sc.o
+	gcc $(CFLAGS) -shared -fPIC -o $@ $(SYMLIB_LINK) $^ $(DEEP_SC_DEFINE)
 
 clean:
 	rm -rf $(EXECS)

--- a/bin/shortcut/deep_sc/deep_sc.c
+++ b/bin/shortcut/deep_sc/deep_sc.c
@@ -8,8 +8,6 @@
 
 my_ksys_read_t my_ksys_read;
 my_ksys_write_t my_ksys_write;
-my_tcp_sendmsg_t tcp_sendmsg;
-my_tcp_recvmsg_t tcp_recvmsg;
 my___fdget_t my___fdget = ((void*)0);
 
 void init_tcp_sc(){


### PR DESCRIPTION
The library linkage rule was using $< for inputs which only grabs the first dependency, switch to $^ for all.

This exposed a multiple definition of the tcp_recvmsg symbol which was resolved by removing it from deep_sc.c and relying on the extern in deep_sc.h.